### PR TITLE
Fix3

### DIFF
--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -637,7 +637,7 @@ def make_tz_naive(val):
 def clean_hex_data(val, val_type):
     if val_type == "address":          # convert to address
         return hex_to_address(val)
-    elif val_type.startswith("uint"):  # convert to float
+    elif val_type.startswith("uint") or val_type.startswith("int"):  # convert to float
         return hex_to_float(val)
     elif val_type == "string":         # keep as hex
         return val

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,12 +31,13 @@ class TestHelpers(object):
         assert ethdata.hex_to_float(10) != ethdata.hex_to_float("10")
         assert ethdata.hex_to_float("0x0000000000000000000000000000000000000000033b2e3c9fd0803ce8000000") == 1e+27
         
-    def clean_hex_data(self):
+    def test_clean_hex_data(self):
         assert ethdata.clean_hex_data("2e6236591bfa37c683ce60d6cfde40396a114ff1", "address") == "0x2e6236591bfa37c683ce60d6cfde40396a114ff1"
         assert ethdata.clean_hex_data("0xdeadbeef", "uint256") == 3_735_928_559
         assert ethdata.clean_hex_data("0xdeadbeef", "uint8") == 3_735_928_559
-        assert ethdata.clean_hex_data("5343484150000000000000000000000000000000000000000000000000000000", "string") == "SCHAP"
+        assert ethdata.clean_hex_data("5343484150000000000000000000000000000000000000000000000000000000", "string") == "5343484150000000000000000000000000000000000000000000000000000000"
         with pytest.warns(UserWarning):
              assert ethdata.clean_hex_data("0xdeadbeef", "unknown") == "0xdeadbeef"
+			 
 
 			 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -33,9 +33,13 @@ class TestHelpers(object):
         
     def test_clean_hex_data(self):
         assert ethdata.clean_hex_data("2e6236591bfa37c683ce60d6cfde40396a114ff1", "address") == "0x2e6236591bfa37c683ce60d6cfde40396a114ff1"
-        assert ethdata.clean_hex_data("0xdeadbeef", "uint256") == 3_735_928_559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int256") == 3_735_928_559
         assert ethdata.clean_hex_data("0xdeadbeef", "uint8") == 3_735_928_559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int256") == 3_735_928_559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int64") == 3_735_928_559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int8") == 3_735_928_559
         assert ethdata.clean_hex_data("5343484150000000000000000000000000000000000000000000000000000000", "string") == "5343484150000000000000000000000000000000000000000000000000000000"
+		
         with pytest.warns(UserWarning):
              assert ethdata.clean_hex_data("0xdeadbeef", "unknown") == "0xdeadbeef"
 			 


### PR DESCRIPTION
Tests for "uint" were added to method test_clean_hex_data() in test_helpers.py.
+
Method clean_hex_data() in ethdata was changed so now data of type 'uint' gets converted to float. 