### PR TITLE
Support for python3.5-3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
-python:
-  - 3.4
-  - 3.5
-  - 3.6
 matrix:
   include:
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
     - python: 3.7
       dist: xenial
       sudo: true
@@ -18,7 +17,7 @@ before_install:
   - openssl aes-256-cbc -K $encrypted_b526b8425f11_key -iv $encrypted_b526b8425f11_iv
     -in gcloud_credentials.json.enc -out gcloud_credentials.json -d
   - pip install cython
-  - pip install numpy1.8
+  - pip install numpy==1.16
 install:
   - python setup.py develop
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 before_install:
   - openssl aes-256-cbc -K $encrypted_b526b8425f11_key -iv $encrypted_b526b8425f11_iv
     -in gcloud_credentials.json.enc -out gcloud_credentials.json -d
+  - pip install cython
+  - pip install numpy1.8
 install:
   - python setup.py develop
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
-  - 3.6-dev
+  - 3.4
+  - 3.5
+  - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 cache: pip
 env:
   global:

--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -728,7 +728,9 @@ class CleanDf:
 
                 self.count = 0
                 raw_rows_string = self.df.at[row.Index, "function_data"]
-                self.raw_rows = [raw_rows_string[i: i + 64] for i in range(0, len(raw_rows_string), 64)]
+                self.raw_rows = []
+                for i in range(0, len(raw_rows_string), 64):
+                    self.raw_rows.append(raw_rows_string[i: i + 64])
 
                 # Iterates through all of the data for a specific row(transaction)
                 for data_name in data:
@@ -815,8 +817,10 @@ class CleanDf:
                 
                 self.count = 0
                 raw_rows_string = self.df.at[row.Index, "transaction_data"]
+                self.raw_rows = []
                 if raw_rows_string:
-                    self.raw_rows = [raw_rows_string[2 + i: i + 66] for i in range(0, len(raw_rows_string), 64)]
+                    for i in range(0, len(raw_rows_string), 64):
+                        self.raw_rows.append(raw_rows_string[2 + i: i + 66])
 
                 # Iterate through data(events)
                 for data_name in data:
@@ -876,30 +880,34 @@ class CleanDf:
 
         array_length = int(clean_hex_data(self.raw_rows[ind], "int"))
         data_type = self.data_type
-        
+        result = []
+
         # String or Bytes
         if data_type == "string" or data_type == "bytes":
             num_rows = int(ceil(array_length/32))
             cut_null = None if (array_length % 32) == 0 else (32 - array_length % 32)*2*-1
             # Iterating through rows of elements and creating a string with them
-            result = clean_hex_data("".join([self.raw_rows[i + ind + 1] for i in range(num_rows)])[:cut_null], data_type) 
+            for i in range(num_rows):
+                result.append(self.raw_rows[i + ind + 1])
             for row_index in range(ind, num_rows + 1 + ind):
                 self.raw_rows[row_index] = None
-            return result
+            return clean_hex_data("".join(result)[:cut_null], data_type)
         # Dynamic-Dynamic array
         elif "[][]" in data_type or data_type == "string[]":
             self.data_type = data_type[:-2]
-            result = [self.dynamic_array(int(hex_to_float(self.raw_rows[ind + 1 +i])/32) + ind + 1) for i in range(array_length)]
+            for i in range(array_length):
+                result.append(self.dynamic_array(int(hex_to_float(self.raw_rows[ind + 1 +i])/32) + ind + 1))
         # Dynamic-Static array
         elif "][]" in data_type:
             self.data_type = data_type.replace("[]", "")
             inner_array_size = int(data_type[data_type.index("[") + 1: data_type.index("][")])
-            result = [self.static_array(i*inner_array_size + ind + 1) for i in range(array_length)]
+            for i in range(array_length):
+                result.append(self.static_array(i*inner_array_size + ind + 1))
         # 1D dynamic array
         else:
             # Iterating through rows of elements and creating a list with them
-            result = [clean_hex_data(self.raw_rows[i + 1 + ind],
-                      data_type.rstrip("[]")) for i in range(array_length)]
+            for i in range(array_length):
+                result.append(clean_hex_data(self.raw_rows[i + 1 + ind], data_type.rstrip("[]")))
         
         # Making used rows empty
         for row_index in range(ind, ind + array_length + 1):
@@ -917,6 +925,7 @@ class CleanDf:
         """
 
         data_type = self.data_type
+        result = []
         
         if data_type.count("[") == 1:
             array_size = int(data_type[data_type.index("[") + 1: -1])
@@ -926,16 +935,19 @@ class CleanDf:
         # Static-Dynamic array
         if "[]" in data_type or "string" in data_type or "bytes" in data_type:
             self.data_type = data_type.replace("[{}]".format(array_size), "")
-            result = [self.dynamic_array(int(hex_to_float(self.raw_rows[ind + i])/32) + ind) for i in range(array_size)]
+            for i in range(array_size):
+                result.append(self.dynamic_array(int(hex_to_float(self.raw_rows[ind + i])/32) + ind))
         # Static-Static array
         elif data_type.count("[") == 2:
             self.data_type = data_type = data_type.replace("[{}]".format(array_size), "")
             inner_array_size = int(data_type[data_type.index("[") + 1: -1])
-            result = [self.static_array(i*(inner_array_size) + ind) for i in range(array_size)]
+            for i in range(array_size):
+                result.append(self.static_array(i*(inner_array_size) + ind))
         # 1D static array
         else:
-            result = [clean_hex_data(self.raw_rows[ind + i], data_type.rstrip(
-                      "[{}]".format(array_size))) for i in range(int(array_size))]
+            for i in range(int(array_size)):
+                result.append(clean_hex_data(self.raw_rows[ind + i], data_type.rstrip("[{}]".format(array_size))))
+
         
         # Making used rows empty
         for row_index in range(ind, ind + array_size):

--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -805,7 +805,7 @@ class CleanDf:
                     stat1 = "[" in  topic_type
                     stat2 = topic_type == "bytes" or "string" in topic_type
                     if stat1 or stat2:
-                        warnings.warn(f"{topic_type} is not yet supported passed as topic")
+                        warnings.warn("{} is not yet supported passed as topic".format(topic_type))
                         self.df.at[row.Index, 'data_' + topic_name] = source
                         t += 1
                         continue
@@ -925,17 +925,17 @@ class CleanDf:
 
         # Static-Dynamic array
         if "[]" in data_type or "string" in data_type or "bytes" in data_type:
-            self.data_type = data_type.replace(f"[{array_size}]", "")
+            self.data_type = data_type.replace("[{}]".format(array_size), "")
             result = [self.dynamic_array(int(hex_to_float(self.raw_rows[ind + i])/32) + ind) for i in range(array_size)]
         # Static-Static array
         elif data_type.count("[") == 2:
-            self.data_type = data_type = data_type.replace(f"[{array_size}]", "")
+            self.data_type = data_type = data_type.replace("[{}]".format(array_size), "")
             inner_array_size = int(data_type[data_type.index("[") + 1: -1])
             result = [self.static_array(i*(inner_array_size) + ind) for i in range(array_size)]
         # 1D static array
         else:
             result = [clean_hex_data(self.raw_rows[ind + i], data_type.rstrip(
-                      f"[{array_size}]")) for i in range(int(array_size))]
+                      "[{}]".format(array_size))) for i in range(int(array_size))]
         
         # Making used rows empty
         for row_index in range(ind, ind + array_size):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -22,7 +22,7 @@ class TestArraysTransactionReceipts:
         my_contract.query_range = {"start": "2019-03-29", "end": "2019-03-29"}
         df = my_contract.transaction_receipts
         returned_data = df.loc[df.transaction_hash == "0x6396ea4d7001cddde13597ea20e9a282f224a9c5db96bf7676bb08b09a3a09e5"].to_dict("r")[0]
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {
@@ -106,7 +106,7 @@ class TestArraysTransactionReceipts:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {
@@ -183,7 +183,7 @@ class TestArraysTransactionReceipts:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_result = {
@@ -256,7 +256,7 @@ class TestArraysTransactionReceipts:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_result = {
@@ -289,7 +289,7 @@ class TestArraysEventLogs:
         my_contract = ethdata.Contract("0x75228dce4d82566d93068a8d5d49435216551599")
         my_contract.query_range = {"start": "2019-04-01", "end": "2019-04-01"}
         df_test = my_contract.event_logs
-        returned_data = df_test.iloc[55]
+        returned_data = df_test.iloc[54]
 
         assert returned_data.data_description == "How many listings will DeFi Pulse have by June 28th, 2019 ? "
         assert returned_data.data_extraInfo == ('{"longDescription":"DeFi Pulse tracks open finance applications '
@@ -680,7 +680,7 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {'param__endTime': [[10.0, 11.0, 12.0], [13.0]]}
@@ -738,7 +738,7 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {'param__endTime': [[1.0, 2.0], [3.0]], 'param__makarov': ['one', 'two', 'three']}
@@ -781,7 +781,7 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {'param__endTime': [("486f77206d616e79206c697374696e67732077696c6c204465"
@@ -827,9 +827,9 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        keys = list(returned_data.keys())[:6]
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
-
         expected_data = {'param__endTime': [[1.0, 4.0], [2.0, 3.0], [9.0, 5.0]]}
 
         for key in returned_data:
@@ -875,7 +875,7 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {'param__endTime': [[2.0, 3.0, 4.0], [1.0, 8.0, 2.0], [4.0, 1.0, 0.0]]}
@@ -920,7 +920,7 @@ class TestTwoDimensionalArrays:
 
         # cleaning data in appropriate format
         returned_data = ethdata.CleanDf().clean_transaction_receipts_df(df, my_contract).iloc[0].to_dict()
-        for key in list(returned_data.keys())[:6]:  # remove unnecessary keys
+        for key in ("transaction_hash", "block_timestamp", "function_name", "from_address", "to_address", "value"):  # remove unnecessary keys
             returned_data.pop(key)
 
         expected_data = {'param__endTime': 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -481,9 +481,11 @@ class TestArraysEventLogs:
             'transaction_data': None
             }, index=[0])
 
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning) as record_all:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
-        record = [warning for warning in record if warning.category == UserWarning]
+        record = []
+        for warning in record_all:
+            record.append(warning) if warning.category == UserWarning else ""
         for n, warning in enumerate(record):
             assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_array_types[n])
 
@@ -577,9 +579,11 @@ class TestArraysEventLogs:
             'transaction_data': None
             }, index=[0])
 
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning) as record_all:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
-        record = [warning for warning in record if warning.category == UserWarning]
+        record = []
+        for warning in record_all:
+            record.append(warning) if warning.category == UserWarning else ""
         for n, warning in enumerate(record):
             assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_array_types[n])
 
@@ -617,9 +621,11 @@ class TestArraysEventLogs:
             'transaction_data': None
             }, index=[0])
 
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning) as record_all:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
-        record = [warning for warning in record if warning.category == UserWarning]
+        record = []
+        for warning in record_all:
+            record.append(warning) if warning.category == UserWarning else ""
         for n, warning in enumerate(record):
             assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_unsupported_types[n])
 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -485,7 +485,7 @@ class TestArraysEventLogs:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
         record = [warning for warning in record if warning.category == UserWarning]
         for n, warning in enumerate(record):
-            assert str(warning.message) == f"{eg_array_types[n]} is not yet supported passed as topic"
+            assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_array_types[n])
 
     def test_dynamic_array_handling_with_data(self):
         my_contract = ethdata.Contract("0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208")
@@ -581,7 +581,7 @@ class TestArraysEventLogs:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
         record = [warning for warning in record if warning.category == UserWarning]
         for n, warning in enumerate(record):
-            assert str(warning.message) == f"{eg_array_types[n]} is not yet supported passed as topic"
+            assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_array_types[n])
 
     def test_2D_array_types_with_topics(self):
         eg_unsupported_types = ['address[][]', 'int8[2][]', 'bytes32[][3]', 'bool[2][3]', 'string[2]', 'string[]']
@@ -621,7 +621,7 @@ class TestArraysEventLogs:
             ethdata.CleanDf().clean_event_logs_df(df, my_contract)
         record = [warning for warning in record if warning.category == UserWarning]
         for n, warning in enumerate(record):
-            assert str(warning.message) == f"{eg_unsupported_types[n]} is not yet supported passed as topic"
+            assert str(warning.message) == "{} is not yet supported passed as topic".format(eg_unsupported_types[n])
 
 
 class TestTwoDimensionalArrays:

--- a/tests/test_class_getter.py
+++ b/tests/test_class_getter.py
@@ -74,7 +74,7 @@ class TestTokenGetters(object):
        assert my_token.name == "Maker"
        assert my_token.symbol == "MKR"
        assert my_token.decimals == 18.0
-       assert my_token.total_supply == 1_000_000
+       assert my_token.total_supply == 1000000
        
     def test_getter_7_valid_token_exception_list(self):
        my_token = ethdata.Token("0xeb9951021698b42e4399f9cbb6267aa35f82d59d")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,20 +24,20 @@ class TestHelpers(object):
 	    assert ethdata.hex_to_string(None) == ""
 
     def test_hex_to_float_method(self):
-        assert ethdata.hex_to_float(1_000_000_000_000_000_000, decimals=18) == 1
+        assert ethdata.hex_to_float(1000000000000000000, decimals=18) == 1
         assert ethdata.hex_to_float(0.123) == 0.123
-        assert ethdata.hex_to_float("0xdeadbeef") == 3_735_928_559
-        assert ethdata.hex_to_float("deadbeef") == 3_735_928_559
+        assert ethdata.hex_to_float("0xdeadbeef") == 3735928559
+        assert ethdata.hex_to_float("deadbeef") == 3735928559
         assert ethdata.hex_to_float(10) != ethdata.hex_to_float("10")
         assert ethdata.hex_to_float("0x0000000000000000000000000000000000000000033b2e3c9fd0803ce8000000") == 1e+27
         
     def test_clean_hex_data(self):
         assert ethdata.clean_hex_data("2e6236591bfa37c683ce60d6cfde40396a114ff1", "address") == "0x2e6236591bfa37c683ce60d6cfde40396a114ff1"
-        assert ethdata.clean_hex_data("0xdeadbeef", "uint256") == 3_735_928_559
-        assert ethdata.clean_hex_data("0xdeadbeef", "uint8") == 3_735_928_559
-        assert ethdata.clean_hex_data("0xdeadbeef", "int256") == 3_735_928_559
-        assert ethdata.clean_hex_data("0xdeadbeef", "int64") == 3_735_928_559
-        assert ethdata.clean_hex_data("0xdeadbeef", "int8") == 3_735_928_559
+        assert ethdata.clean_hex_data("0xdeadbeef", "uint256") == 3735928559
+        assert ethdata.clean_hex_data("0xdeadbeef", "uint8") == 3735928559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int256") == 3735928559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int64") == 3735928559
+        assert ethdata.clean_hex_data("0xdeadbeef", "int8") == 3735928559
         assert ethdata.clean_hex_data("5343484150000000000000000000000000000000000000000000000000000000", "string") == "SCHAP"
         assert ethdata.clean_hex_data(0, "bool") == False
         with pytest.warns(UserWarning):


### PR DESCRIPTION
Changes:
1. [.travis.yml] Modules pip cython and numpy problematic with python 3.5 and 3.6 so they had to be installed manually for testing in Travis (they work fine locally without manual installation).
2. [test_arrays.py] Slight changes with iteration and now unnecessary elements are removed key specific
3. [test_helpers.py & test_class_getters.py] Underscores in digits removed
4. [ethdata.py] f string formatting removed and dictionary replaced with a sorted dictionary (python 3.6 on makes default dict sorted one)
