### PR TITLE
URL fix + some optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,27 @@ Offers developers and analysts a simple way to extract and analyse historical Et
 
 https://docs.blocklytics.org/ethdata/introduction
 
+Note you will need set two environment variables:
+
+- GOOGLE_APPLICATION_CREDENTIALS set to your json service account key. See [here](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries) for how to create this
+- ETHERSCAN_API_KEY. Key can be created for free on https://etherscan.io
+
 # GitHub
 
 https://github.com/blocklytics/eth-data-tools
 
-# How to contribute / install locally
+# How to install from local copy
 
-- Fork your own copy
 - git clone locally
 - conda create --name ethdata
 - condo activate ethdata
 - conda install pip
-- which pip [just to check you're now referring to the pip in your condo env]
+- which pip [just to check you're now referring to the pip in your conda env]
 - pip install -e . [this installs the package into ethdata according to the setup.py instructions]
 - conda install pytest-cov [required to run the tests]
+
+# How to install from remote
+
+This package is hosted here: https://pypi.org/project/eth-data-tools/
+
+pip install eth-data-tools

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ https://docs.blocklytics.org/ethdata/introduction
 # GitHub
 
 https://github.com/blocklytics/eth-data-tools
+
+# How to contribute / install locally
+
+- Fork your own copy
+- git clone locally
+- conda create --name ethdata
+- condo activate ethdata
+- conda install pip
+- which pip [just to check you're now referring to the pip in your condo env]
+- pip install -e . [this installs the package into ethdata according to the setup.py instructions]
+- conda install pytest-cov [required to run the tests]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Offers developers and analysts a simple way to extract and analyse historical Et
 
 https://docs.blocklytics.org/ethdata/introduction
 
-Note you will need set two environment variables:
+Note you will need to set two environment variables:
 
 - GOOGLE_APPLICATION_CREDENTIALS set to your json service account key. See [here](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries) for how to create this
 - ETHERSCAN_API_KEY. Key can be created for free on https://etherscan.io

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ https://docs.blocklytics.org/ethdata/introduction
 
 Note you will need to set two environment variables:
 
-- GOOGLE_APPLICATION_CREDENTIALS set to your json service account key. See [here](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries) for how to create this
-- ETHERSCAN_API_KEY. Key can be created for free on https://etherscan.io
+- `GOOGLE_APPLICATION_CREDENTIALS` set to your json service account key. See [here](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries) for how to create this
+- `ETHERSCAN_API_KEY`. Key can be created for free on https://etherscan.io
 
 # GitHub
 
@@ -26,15 +26,15 @@ https://github.com/blocklytics/eth-data-tools
 # How to install from local copy
 
 - git clone locally
-- conda create --name ethdata
-- condo activate ethdata
-- conda install pip
-- which pip [just to check you're now referring to the pip in your conda env]
-- pip install -e . [this installs the package into ethdata according to the setup.py instructions]
-- conda install pytest-cov [required to run the tests]
+- `conda create --name ethdata python=3.9.4`: create a new conda env
+- `condo activate ethdata`
+- `conda install pip`: your new env might not have `pip` installed by default
+- `which pip`: just to check you're now referring to the pip in your conda env
+- `pip install -e .`: this installs the package into ethdata according to the `setup.py` instructions
+- `conda install pytest-cov`: required to run the tests
 
 # How to install from remote
 
 This package is hosted here: https://pypi.org/project/eth-data-tools/
 
-pip install eth-data-tools
+`pip install eth-data-tools`

--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -527,9 +527,9 @@ LIMIT 1""".format(public_dataset['traces'], contract.address)
         
         date_sql = ""
         if 'start' in contract.query_range:
-            date_sql += "AND block_timestamp >= \"{0}\"".format(dt.datetime.strptime(contract.query_range['start'], '%Y-%m-%d'))
+            date_sql += "AND block_timestamp >= \"{0}\"".format(contract.query_range['start'])
         if 'end' in contract.query_range:
-            date_sql += "\nAND block_timestamp < \"{0}\"".format(dt.datetime.strptime(contract.query_range['end'], '%Y-%m-%d') + dt.timedelta(days=1))
+            date_sql += "\nAND block_timestamp < \"{0}\"".format(contract.query_range['end'])
             
         sql = """
 SELECT
@@ -574,9 +574,9 @@ WHERE address = "{1}"
         
         date_sql = ""
         if 'start' in account.query_range:
-            date_sql += "AND block_timestamp >= \"{0}\"\n".format(dt.datetime.strptime(account.query_range['start'], '%Y-%m-%d'))
+            date_sql += "AND block_timestamp >= \"{0}\"\n".format(account.query_range['start'])
         if 'end' in account.query_range:
-            date_sql += "AND block_timestamp < \"{0}\"".format(dt.datetime.strptime(account.query_range['end'], '%Y-%m-%d') + dt.timedelta(days=1))
+            date_sql += "AND block_timestamp < \"{0}\"".format(account.query_range['end'])
             
         sql = """
 SELECT

--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -12,13 +12,13 @@ from collections import OrderedDict
 
 # BigQuery Public Ethereum Datasets
 public_dataset = {
-    "blocks": "bigquery-public-data.ethereum_blockchain.blocks"
-    ,"contracts": "bigquery-public-data.ethereum_blockchain.contracts"
-    ,"logs": "bigquery-public-data.ethereum_blockchain.logs"
-    ,"token_transfers": "bigquery-public-data.ethereum_blockchain.token_transfers"
-    ,"tokens": "bigquery-public-data.ethereum_blockchain.tokens"
-    ,"traces": "bigquery-public-data.ethereum_blockchain.traces"
-    ,"transactions": "bigquery-public-data.ethereum_blockchain.transactions"
+    "blocks": "bigquery-public-data.crypto_ethereum.blocks"
+    ,"contracts": "bigquery-public-data.crypto_ethereum.contracts"
+    ,"logs": "bigquery-public-data.crypto_ethereum.logs"
+    ,"token_transfers": "bigquery-public-data.crypto_ethereum.token_transfers"
+    ,"tokens": "bigquery-public-data.crypto_ethereum.tokens"
+    ,"traces": "bigquery-public-data.crypto_ethereum.traces"
+    ,"transactions": "bigquery-public-data.crypto_ethereum.transactions"
 }
 
 # Exception list

--- a/ethdata/ethdata.py
+++ b/ethdata/ethdata.py
@@ -110,6 +110,8 @@ class Contract(Account):
         self.abi = None
         self.creation_date = None
         self.event_logs = None
+        self.functions = None
+        self.events = None
         
     @property
     def abi(self):
@@ -160,57 +162,67 @@ class Contract(Account):
 
     @property
     def functions(self):
-        self.__functions = {}
-        for item in self.abi:
-            if item['type'] == 'function':
-                function_name = item['name']
-                input_types = []
-                data = OrderedDict()
-                        
-                for input_ in item['inputs']:
-                    input_types.append(input_['type'])
-                    data.update({input_['name']: input_['type']})
-                            
-                function_prehash = "{0}({1})".format(function_name, ",".join(input_types))
-                function_signature = get_function_signature(function_prehash)
-                        
-                self.__functions[function_signature] = {
-                    "function_name": function_name,
-                    "data": data
-                }
+        if self.__functions is None:
+            self.__functions = {}
+            for item in self.abi:
+                if item['type'] == 'function':
+                    function_name = item['name']
+                    input_types = []
+                    data = OrderedDict()
+
+                    for input_ in item['inputs']:
+                        input_types.append(input_['type'])
+                        data.update({input_['name']: input_['type']})
+
+                    function_prehash = "{0}({1})".format(function_name, ",".join(input_types))
+                    function_signature = get_function_signature(function_prehash)
+
+                    self.__functions[function_signature] = {
+                        "function_name": function_name,
+                        "data": data
+                    }
         return self.__functions
+
+    @functions.setter
+    def functions(self, val):
+        self.__functions = val
     
     @property
     def events(self):
-        self.__events = {}
-        for item in self.abi:
-            if item['type'] == 'event':
-                event_name = item['name']
-                input_types = []
-                topics = OrderedDict()
-                data = OrderedDict()
-                anonymous = item['anonymous']
-                        
-                for input_ in item['inputs']:
-                    input_types.append(input_['type'])
-                                
-                    if input_['indexed']:
-                        topics.update({input_['name']: input_['type']})
+        if self.__events is None:
+            self.__events = {}
+            for item in self.abi:
+                if item['type'] == 'event':
+                    event_name = item['name']
+                    input_types = []
+                    topics = OrderedDict()
+                    data = OrderedDict()
+                    anonymous = item['anonymous']
+
+                    for input_ in item['inputs']:
+                        input_types.append(input_['type'])
+
+                        if input_['indexed']:
+                            topics.update({input_['name']: input_['type']})
+                        else:
+                            data.update({input_['name']: input_['type']})
+
+                    if not anonymous:
+                        event_prehash = "{0}({1})".format(event_name, ",".join(input_types))
+                        event_hash = get_event_hash(event_prehash)
                     else:
-                        data.update({input_['name']: input_['type']})
-                    
-                if not anonymous:
-                    event_prehash = "{0}({1})".format(event_name, ",".join(input_types))
-                    event_hash = get_event_hash(event_prehash)
-                else:
-                    event_hash = "Anonymous"
-                        
-                self.__events[event_hash] = {
-                    "event_name": event_name,
-                    "topics": topics,
-                    "data": data
-                }
+                        event_hash = "Anonymous"
+
+                    self.__events[event_hash] = {
+                        "event_name": event_name,
+                        "topics": topics,
+                        "data": data
+                    }
         return self.__events
+
+    @events.setter
+    def events(self, val):
+        self.__events = val
 
 ###############
 # TOKEN CLASS #


### PR DESCRIPTION
This branch contains:

- URL fixes: `ethereum_blockchain` moved to `crypto_ethereum` some time in 2018. See here: https://evgemedvedev.medium.com/ethereum-blockchain-on-google-bigquery-283fb300f579
- Add caches for `functions` and `events` in the same way there is already for `event_logs` already. These get called very frequently, and although the etherscan call isn't duplicated, it's still unnecessary to rerun them
- no longer insist on date format `%Y-%m-%d` for `start` and `end`, which allows users to submit more granular time intervals. If `start = "2022-12-31"` is submitted, then this is interpreted by BigQuery as `"2022-12-31 00:00:00"` so the change is backwards compatible
- Add more information to the README